### PR TITLE
[EN-1419] Specifies a version for setuptools, to minimize possibility of download errors

### DIFF
--- a/tasks/centos6.yml
+++ b/tasks/centos6.yml
@@ -37,7 +37,7 @@
   when: easy_install_check|failed
 
 - name: install setuptools
-  command: /usr/bin/{{ executable_python }} ez_setup.py
+  command: "/usr/bin/{{ executable_python }} ez_setup.py --version=19.6.2"
   args: { chdir: /tmp }
   when: easy_install_check|failed
 


### PR DESCRIPTION
Story: http://jira.juwai.com/browse/EN-1419
- Specifies a version for setuptools, to minimize possibility of download errors

How to test:
1. Provision a new vagrant box using specs from `tests`; or
2. Provision a new Juwai-admin vagrant box

/cc @tjoelsson @imlazyone @juwai/platform Please review. Thanks.
