### PR TITLE
Don't use shortened URL for ve

### DIFF
--- a/tasks/ve.yml
+++ b/tasks/ve.yml
@@ -1,6 +1,9 @@
 ---
 - name: install ve
-  get_url: url=https://git.io/ve dest=/usr/local/bin/ve mode=0755
+  get_url:
+    url: 'https://raw.githubusercontent.com/erning/ve/master/ve'
+    dest: '/usr/local/bin/ve'
+    mode: 0755
 
 - name: make ve available on path
   alternatives: name=ve link=/usr/bin/ve path=/usr/local/bin/ve


### PR DESCRIPTION
## Summary of changes

- The shortened URL `git.io/ve` requires SNI, so it fails when using Python 2.6. Using the full Github URL instead.

## How to Test

Run a playbook that includes this role.