### PR TITLE
Plat 632 Unit test error in juwai-rpc vagrant box

### DIFF
--- a/tasks/centos6.yml
+++ b/tasks/centos6.yml
@@ -2,8 +2,8 @@
 - name: ensure openssl-devel present
   yum: name=openssl-devel state=present
 
-- name: ensure openssl-devel present
-  yum: name=openssl-devel state=present
+- name: ensure sqlite-devel present
+  yum: name=sqlite-devel state=present
   when: env == 'vagrant'
 
 - name: download {{ executable_python }} source

--- a/tasks/centos6.yml
+++ b/tasks/centos6.yml
@@ -2,6 +2,10 @@
 - name: ensure openssl-devel present
   yum: name=openssl-devel state=present
 
+- name: ensure openssl-devel present
+  yum: name=openssl-devel state=present
+  when: env == 'vagrant'
+
 - name: download {{ executable_python }} source
   get_url:
     url: http://python.org/ftp/python/{{ py_version }}/Python-{{ py_version }}.tar.xz


### PR DESCRIPTION
## Summary of changes

we should download sqlite3.tar.gz and install it before the installation of python27.

## How to Test
```
Start juwai-rpc vagrant box
Go to /vagrant
Run $ ve python setup.py test
```

/fyi: @tjoelsson : Please review.

/cc: @zhangjustin : Need your input regarding _concern_.